### PR TITLE
fix(navbar): fix page crash issues in the sidenav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "td-ai-unlimited-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@bsahitya/td-doc-design": "^0.1.9",
+        "@bsahitya/td-doc-design": "^0.1.2",
         "@docusaurus/core": "3.2.0",
         "@docusaurus/preset-classic": "3.2.0",
         "@mdx-js/react": "^3.0.0",
@@ -2140,9 +2140,9 @@
       }
     },
     "node_modules/@bsahitya/td-doc-design": {
-      "version": "0.1.9",
-      "resolved": "https://npm.pkg.github.com/download/@bsahitya/td-doc-design/0.1.9/2c635dfee8410cde07d6be671ad31afc2a784cc8",
-      "integrity": "sha512-pKGWYy3cOp3afT+BiuY8+8kdPGaNMdcldaZ3JCCeRvYGMJkeLve59Sn+oeNaMNxEvlQZBFzsS+o7NiZroRmGnQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@bsahitya/td-doc-design/-/td-doc-design-0.1.2.tgz",
+      "integrity": "sha512-Y2LasJVXrtN1F4XO71Illu53lM3CIGctKCTLOb/AYC5v8vorVkQtpcexrgOZ3/Qk/gHsqAFr1po0RjptcKCR9Q==",
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@bsahitya/td-doc-design": "^0.1.0",
+    "@bsahitya/td-doc-design": "^0.1.2",
     "@docusaurus/core": "3.2.0",
     "@docusaurus/preset-classic": "3.2.0",
     "@mdx-js/react": "^3.0.0",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,7 +23,6 @@
   --ifm-color-danger: #b11d00;
 
   --ifm-background-surface-color: #ffffff;
-
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -38,9 +37,16 @@ html[data-theme='dark'] {
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --ifm-navbar-background-color: #28353b;
   --ifm-background-color: #161c1f;
-  --ifm-footer-background-color:var(--ifm-navbar-background-color);
+  --ifm-footer-background-color: var(--ifm-navbar-background-color);
 }
 
+.navbar {
+  background-color: unset;
+  box-shadow: none;
+  display: unset;
+  height: unset;
+  padding: 0;
+}
 
 .navbar__logo {
   height: 1.5rem;
@@ -48,5 +54,4 @@ html[data-theme='dark'] {
 
 .footer--dark {
   --ifm-footer-background-color: #28353b;
-
 }


### PR DESCRIPTION
### Bug
While clicking on some of the side nav items, the pages crash.

### Rootcause
Issue is being caused by one of docusaurus hooks which calculates clientheight of the navbar based on the `.navbar` class.

### Fix
Added the `navbar` class to custom react header and removed docusaurus navbar styles.